### PR TITLE
Add tests and update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -434,10 +434,6 @@
 	path = apps/imminence
 	url = git@github.com:alphagov/imminence.git
 	branch = master
-[submodule "apps/projectjellyfish-api"]
-	path = apps/projectjellyfish-api
-	url = git@github.com:projectjellyfish/api.git
-	branch = master
 [submodule "apps/foodsoft"]
 	path = apps/foodsoft
 	url = git@github.com:foodcoops/foodsoft.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -534,7 +534,7 @@
 [submodule "apps/rubytogether.org"]
 	path = apps/rubytogether.org
 	url = git@github.com:rubytogether/rubytogether.org.git
-	branch = master
+	branch = main
 [submodule "engines/exception_notification"]
 	path = engines/exception_notification
 	url = git@github.com:smartinez87/exception_notification.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+git:
+    submodules: false
+install: bundle install
+script: "bundle exec rspec spec"


### PR DESCRIPTION
- Removes `apps/projectjellyfish-api`, as it no longer appears to exist
- Updates branch for `rubytogether.org`
- Adds basic `.travis.yml`

With these changes you could add Dependabot to this repo with automerging switched on, as described in https://github.com/eliotsykes/real-world-rails/issues/64, and it should just work.