### PR TITLE
Remove @coopdevs / katuma - abandoned in favor of openfoodnetwork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -759,10 +759,6 @@
 	path = apps/timeoverflow
 	url = git@github.com:coopdevs/timeoverflow.git
 	branch = develop
-[submodule "apps/katuma"]
-	path = apps/katuma
-	url = git@github.com:coopdevs/katuma.git
-	branch = develop
 [submodule "apps/openfoodnetwork"]
 	path = apps/openfoodnetwork
 	url = git@github.com:openfoodfoundation/openfoodnetwork.git


### PR DESCRIPTION
Cf README at https://github.com/coopdevs/katuma.

You can close this PR if you think that it is worth keeping this entry for archival purposes.