### PR TITLE
Change mastodon from @Gargron / mastodon to @tootsuite / mastodon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -639,10 +639,6 @@
 	path = apps/klaxon
 	url = git@github.com:themarshallproject/klaxon.git
 	branch = master
-[submodule "apps/mastodon"]
-	path = apps/mastodon
-	url = git@github.com:Gargron/mastodon.git
-	branch = master
 [submodule "apps/cm42-central"]
 	path = apps/cm42-central
 	url = git@github.com:Codeminer42/cm42-central.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -863,3 +863,7 @@
 	path = engines/heya
 	url = git@github.com:honeybadger-io/heya.git
 	branch = master
+[submodule "apps/mastodon"]
+	path = apps/mastodon
+	url = git@github.com:tootsuite/mastodon.git
+	branch = master


### PR DESCRIPTION
https://github.com/Gargron/mastodon hasn't been updated in 3 years.

Active development of Mastodon has moved to https://github.com/tootsuite/mastodon.