### PR TITLE
remove shoppe (deleted repo)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -170,10 +170,6 @@
 	path = apps/bridge_troll
 	url = git@github.com:railsbridge/bridge_troll.git
 	branch = master
-[submodule "apps/shoppe"]
-	path = apps/shoppe
-	url = git@github.com:tryshoppe/shoppe.git
-	branch = master
 [submodule "apps/whitehall"]
 	path = apps/whitehall
 	url = git@github.com:alphagov/whitehall.git


### PR DESCRIPTION
Removes `tryshoppe/shoppe` submodule as it's not available anymore.